### PR TITLE
Clarify reboot flag storage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -297,7 +297,7 @@ This release introduces smart DNS monitoring with configurable timing, improved 
 **NEW MODULE**: `src/system_utils.h/cpp`
 
 - **Safe Device Reboots**: `rebootDevice()` with logging and delay
-- **Remote Reboot Flags**: `setRebootFlag()` for web-triggered reboots
+- **Remote Reboot Flags**: `setRebootFlag()` uses NVS/Preferences for web-triggered reboots
 - **Uptime Formatting**: `formatUptime()` utility for consistent time displays
 - **Persistent Logging**: Reboot reasons stored in preferences
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Once configured, these entities automatically appear in Home Assistant:
 
 **Controls:**
 - **Alert Control Switch** - Enable/disable notifications remotely
-- **Reboot Button** - Safely reboot the device from Home Assistant
+- **Reboot Button** - Safely reboot the device from Home Assistant (stores request in NVS/Preferences)
 
 **Features:**
 - **Availability Monitoring** - Home Assistant tracks device online/offline status

--- a/src/system_utils.h
+++ b/src/system_utils.h
@@ -6,7 +6,7 @@
 // Reboot the ESP32 with optional delay and message
 void rebootDevice(unsigned long delayMs = 3000, const char* reason = "Manual reboot");
 
-// Check if a reboot was requested via file flag
+// Check if a reboot was requested via flag in NVS (Preferences)
 bool checkRebootFlag();
 
 // Set a reboot flag (for remote reboot requests)


### PR DESCRIPTION
## Summary
- Document that remote reboot flags are stored in ESP32 NVS/Preferences
- Update reboot flag comment to reflect NVS storage instead of file

## Testing
- `pio run` *(fails: credentials.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68973fe6309c83289ccdeabe92bffb7a