### PR TITLE
fix(#31): distinct sample primary/fallback DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ Create dashboards with:
 
 The ESP32 features intelligent DNS monitoring with configurable alerting to prevent notification spam while ensuring you're informed of important network issues.
 
+### Recommended DNS topology
+
+Configure **two different** resolvers in `src/config.cpp` (`primaryDNS` and `fallbackDNS`):
+
+| Role | Recommendation | Example |
+|------|----------------|---------|
+| **Primary** | Local recursive or filtering DNS on your LAN | Pi-hole / AdGuard (`192.168.x.x`) |
+| **Fallback** | A second, independent resolver | Another local DNS host, or a public resolver (`1.1.1.1`, `8.8.8.8`, router DNS) |
+
+- Fallback only helps when it is **not** the same IP as primary. Identical values disable meaningful failover (the firmware treats that as a single server and skips critical dual-failure alerts).
+- Prefer a local primary for filtering/latency, and a distinct fallback so brief primary outages do not take the device fully offline.
+- Sample defaults use a local primary example and Cloudflare (`1.1.1.1`) as fallback — replace both with addresses that match your network.
+
+At boot, if primary and fallback are equal, the serial/telnet log emits a **WARNING** that fallback is a no-op.
+
 ### Key Features
 
 **🕐 Smart Timing Logic:**

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,8 +13,11 @@ const char* otaPassword = OTA_PASSWORD;
 const char* deviceName = "poop-monitor";
 
 // DNS Configuration
-IPAddress primaryDNS(192, 168, 68, 51);    // Your custom DNS server
-IPAddress fallbackDNS(192, 168, 68, 51);         
+// Use DISTINCT servers so fallback is real. Same IP for both makes failover a no-op.
+// Recommended: primary = local recursive/filter (Pi-hole, AdGuard, etc.);
+//              fallback = a second resolver (another local box or a public DNS).
+IPAddress primaryDNS(192, 168, 68, 51);  // Local DNS example (e.g. Pi-hole)
+IPAddress fallbackDNS(1, 1, 1, 1);      // Distinct fallback example (Cloudflare)
 
 // Pushover Configuration (from credentials.h)
 const char* pushoverToken = PUSHOVER_TOKEN;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,11 @@ void setup() {
     WiFi.config(WiFi.localIP(), WiFi.gatewayIP(), WiFi.subnetMask(), primaryDNS, fallbackDNS);
     Serial.printf("[%10lu ms] [DNS] Configured DNS - Primary: %s, Fallback: %s\r\n", 
                   millis(), primaryDNS.toString().c_str(), fallbackDNS.toString().c_str());
+    if (primaryDNS == fallbackDNS) {
+      Serial.printf("[%10lu ms] [DNS] WARNING: primary and fallback DNS are identical (%s); "
+                    "fallback is a no-op. Configure distinct servers in config.cpp.\r\n",
+                    millis(), primaryDNS.toString().c_str());
+    }
     
     // Test DNS resolution
     testDNSResolution();


### PR DESCRIPTION
## Summary
Fixes sample config where `primaryDNS` and `fallbackDNS` were the same IP, so DNS fallback was a no-op if copied as-is.

## Changes
- **Sample config** (`src/config.cpp`): primary stays a local DNS example; fallback is now Cloudflare `1.1.1.1` with comments on recommended topology
- **Runtime warning** (`src/main.cpp`): serial log warns when primary == fallback after WiFi DNS is configured
- **Docs** (`README.md`): recommended DNS topology (local primary + distinct fallback)

## Acceptance criteria
- [x] Sample uses distinct primary/fallback examples
- [x] Runtime warns if primary == fallback
- [x] Docs explain recommended topology

Closes #31