### PR TITLE
fix: make heartbeat URL configurable (#32)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 # Recent Changes Summary
 
+## Unreleased
+
+- **Configurable heartbeat endpoint** - Replaced hard-coded `apiEndpoint` (`/heartbeat/poop`) with `heartbeatBaseUrl`, `heartbeatDeviceId`, and optional `heartbeatPath` override (`getHeartbeatEndpoint()`).
+- **notification-api contract docs** - Added `docs/HEARTBEAT.md` describing the HTTP GET contract, silence-timeout behavior, and a generic `/health` example.
+
 ## 2.6.2 - OTA Rollback Protection + v2.6.1 Merged Features
 
 **Major Release: Automatic Firmware Rollback Protection + Build Optimization**

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Edit `src/config.cpp` with your actual values:
 const char* ssid = "YOUR_WIFI_SSID";
 const char* password = "YOUR_WIFI_PASSWORD";
 
+// Heartbeat / notification-api (see docs/HEARTBEAT.md)
+// Default resolves to {base}/heartbeat/{deviceId}
+const char* heartbeatBaseUrl = "http://notifications.example.com"; // no trailing slash
+const char* heartbeatDeviceId = "poop";           // notification-api path segment
+const char* heartbeatPath = "";                   // or "/health" for a generic probe
+
 // OTA Configuration  
 const char* otaPassword = "YOUR_OTA_PASSWORD";
 
@@ -93,6 +99,8 @@ const int mqttPort = 1883;                     // MQTT port
 const char* mqttUser = "";                     // MQTT username (empty if no auth)
 const char* mqttPassword = "";                 // MQTT password (empty if no auth)
 ```
+
+**Heartbeat URL** is no longer a single hard-coded path: set `heartbeatBaseUrl` + `heartbeatDeviceId`, or set `heartbeatPath` (e.g. `"/health"`) for a generic health endpoint. Full contract: [`docs/HEARTBEAT.md`](docs/HEARTBEAT.md).
 
 ### File Structure
 

--- a/docs/HEARTBEAT.md
+++ b/docs/HEARTBEAT.md
@@ -1,0 +1,97 @@
+# Heartbeat / notification-api Contract
+
+The firmware periodically issues an HTTP **GET** to a configurable endpoint so an external watcher can detect device silence (and alert via Pushover, etc.).
+
+This document describes how the ESP32 builds that URL, what it expects from the server, and how to point the device at **notification-api** or a generic health probe.
+
+## Configuration (firmware)
+
+Set these in `src/config.cpp`:
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `heartbeatBaseUrl` | Scheme + host (+ optional port). **No trailing slash.** | `http://notifications.example.com` |
+| `heartbeatDeviceId` | Path segment used by notification-api | `poop`, `garage`, `lab-esp32` |
+| `heartbeatPath` | Optional full path override. Empty = derive path. | `""` or `"/health"` |
+
+Resolved URL (`getHeartbeatEndpoint()`):
+
+1. If `heartbeatPath` is **non-empty**: `{heartbeatBaseUrl}{heartbeatPath}`
+2. Else: `{heartbeatBaseUrl}/heartbeat/{heartbeatDeviceId}`
+
+`deviceName` (e.g. `poop-monitor`) is separate: it is used for mDNS / identity, **not** for the heartbeat path unless you choose matching values.
+
+### Default (notification-api legacy)
+
+```cpp
+const char* heartbeatBaseUrl = "http://notifications.archerfamily.io";
+const char* heartbeatDeviceId = "poop";
+const char* heartbeatPath = "";  // → /heartbeat/poop
+// Resolved: http://notifications.archerfamily.io/heartbeat/poop
+```
+
+### Example: different device id on notification-api
+
+```cpp
+const char* heartbeatBaseUrl = "http://notifications.example.com";
+const char* heartbeatDeviceId = "garage";
+const char* heartbeatPath = "";
+// Resolved: http://notifications.example.com/heartbeat/garage
+```
+
+> **Server note:** stock notification-api currently registers a hard-coded route
+> `GET /heartbeat/poop`. Deployments that need other device ids must expose a
+> matching route (or a parameterized `/heartbeat/{id}`) on the API side.
+
+### Example: generic health endpoint
+
+Use any probe that returns **HTTP 200** on success (Kubernetes/Traefik/nginx health, uptime-kuma push/http, a static `/health`, etc.):
+
+```cpp
+const char* heartbeatBaseUrl = "http://status.example.com";
+const char* heartbeatDeviceId = "unused-when-path-set";
+const char* heartbeatPath = "/health";
+// Resolved: http://status.example.com/health
+```
+
+Other path examples: `"/ping"`, `"/api/v1/health"`, `"/readyz"`.
+
+## HTTP contract (device → server)
+
+| Item | Behavior |
+|---|---|
+| Method | `GET` |
+| URL | Value of `getHeartbeatEndpoint()` |
+| Body | None |
+| Timeout | 10 seconds (firmware) |
+| Interval | ~5 seconds between attempts (main loop delay) |
+| Success | HTTP status **200** (response body is logged only; content is not parsed) |
+| Failure | Non-200 or transport error; response code stored for status/MQTT |
+
+The device does **not** send auth headers or a JSON body. Keep the endpoint simple and unauthenticated only if appropriate for your network threat model (prefer private network / reverse-proxy ACL).
+
+## notification-api behavior (server → operator)
+
+Reference implementation: [Josh-Archer/notification-api](https://github.com/Josh-Archer/notification-api).
+
+| Item | Behavior |
+|---|---|
+| Route (current) | `GET /heartbeat/poop` |
+| Response | `200` with body `OK` |
+| Side effect | Updates in-memory last-seen timestamp |
+| Silence alert | If no successful heartbeat for `HEARTBEAT_TIMEOUT_SECS` (default **90**), send Pushover alert |
+| Check cadence | Server loop interval `CHECK_INTERVAL_SECS` (default **10**) |
+
+Implication for the device: with a ~5s ping interval and a 90s timeout, a few dropped packets will not false-alarm; sustained disconnects will.
+
+## Observability on the device
+
+- Telnet: `[Heartbeat] Ping Response (200): ...` / failure strings
+- Web/MQTT status (when enabled): `heartbeat_endpoint`, `heartbeat_base_url`, `heartbeat_device_id`, `heartbeat_path`, last success/code
+
+## Checklist when changing the URL
+
+1. Update `heartbeatBaseUrl` / `heartbeatDeviceId` / `heartbeatPath` in `src/config.cpp`.
+2. Ensure the server route matches (notification-api path or your generic health path).
+3. Rebuild and flash; confirm 200 responses in telnet or `/status`.
+4. Confirm the watcher’s silence timeout is greater than a few missed intervals.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "credentials.h"
+#include <cstdio>
 
 const char* firmwareVersion = "2.9.0";
 
@@ -7,8 +8,33 @@ const char* firmwareVersion = "2.9.0";
 const char* ssid = WIFI_SSID;
 const char* password = WIFI_PASSWORD;
 
-// API Configuration
-const char* apiEndpoint = "http://notifications.archerfamily.io/heartbeat/poop";
+// Heartbeat / notification-api configuration
+// Contract: device issues HTTP GET to the resolved endpoint; success = HTTP 200.
+// notification-api (legacy): GET /heartbeat/{device_id}  e.g. /heartbeat/poop
+// Generic health example: set heartbeatPath = "/health" (or any path your probe accepts).
+// Base URL must not include a trailing slash.
+const char* heartbeatBaseUrl = "http://notifications.archerfamily.io";
+const char* heartbeatDeviceId = "poop";
+// Leave empty to use /heartbeat/{heartbeatDeviceId}. Override for non-notification-api targets.
+const char* heartbeatPath = "";
+
+static char heartbeatEndpointBuf[256];
+static bool heartbeatEndpointReady = false;
+
+const char* getHeartbeatEndpoint() {
+  if (!heartbeatEndpointReady) {
+    if (heartbeatPath != nullptr && heartbeatPath[0] != '\0') {
+      snprintf(heartbeatEndpointBuf, sizeof(heartbeatEndpointBuf), "%s%s",
+               heartbeatBaseUrl, heartbeatPath);
+    } else {
+      snprintf(heartbeatEndpointBuf, sizeof(heartbeatEndpointBuf), "%s/heartbeat/%s",
+               heartbeatBaseUrl, heartbeatDeviceId);
+    }
+    heartbeatEndpointReady = true;
+  }
+  return heartbeatEndpointBuf;
+}
+
 const char* otaPassword = OTA_PASSWORD;
 const char* deviceName = "poop-monitor";
 

--- a/src/config.h
+++ b/src/config.h
@@ -11,8 +11,17 @@ extern const char* firmwareVersion;
 extern const char* ssid;
 extern const char* password;
 
-// API Configuration
-extern const char* apiEndpoint;
+// Heartbeat / notification-api configuration
+// Full URL is resolved at runtime by getHeartbeatEndpoint():
+//   - if heartbeatPath is non-empty: {heartbeatBaseUrl}{heartbeatPath}
+//   - else: {heartbeatBaseUrl}/heartbeat/{heartbeatDeviceId}
+// See docs/HEARTBEAT.md for the notification-api contract and examples.
+extern const char* heartbeatBaseUrl;   // no trailing slash
+extern const char* heartbeatDeviceId;  // path segment for notification-api
+extern const char* heartbeatPath;      // optional full path override (e.g. "/health")
+const char* getHeartbeatEndpoint();    // resolved URL used for the periodic GET
+
+// Device / OTA
 extern const char* otaPassword;
 extern const char* deviceName;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,7 +209,7 @@ void loop() {
 
   WiFiClient client;
   HTTPClient http;
-  http.begin(client, apiEndpoint);
+  http.begin(client, getHeartbeatEndpoint());
   http.setTimeout(10000);
   
   int httpCode = http.GET();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -75,7 +75,12 @@ void handleStatus() {
   // Heartbeat
   doc["last_heartbeat_success"] = lastSuccessfulHeartbeat;
   doc["last_heartbeat_code"] = lastHeartbeatResponseCode;
-  doc["heartbeat_endpoint"] = apiEndpoint;
+  doc["heartbeat_endpoint"] = getHeartbeatEndpoint();
+  doc["heartbeat_base_url"] = heartbeatBaseUrl;
+  doc["heartbeat_device_id"] = heartbeatDeviceId;
+  doc["heartbeat_path"] = (heartbeatPath != nullptr && heartbeatPath[0] != '\0')
+                              ? heartbeatPath
+                              : "(derived /heartbeat/{device_id})";
 
   unsigned long timeSinceLastSuccessMs = millis() - lastSuccessfulHeartbeat;
   doc["time_since_last_success_ms"] = timeSinceLastSuccessMs;


### PR DESCRIPTION
## Summary
- Replace hard-coded `apiEndpoint` (`http://.../heartbeat/poop`) with configurable `heartbeatBaseUrl`, `heartbeatDeviceId`, and optional `heartbeatPath` override via `getHeartbeatEndpoint()`.
- Document the notification-api HTTP GET contract, silence timeout behavior, and a generic `/health` example in `docs/HEARTBEAT.md`.
- Expose resolved endpoint and config parts on the web status API for debugging.

## Acceptance criteria
- [x] Configurable heartbeat path/device id
- [x] Document contract with notification-api
- [x] Example for generic health endpoint

## Test plan
- [ ] Confirm default config still resolves to `.../heartbeat/poop`
- [ ] Build firmware (any env) and verify no `apiEndpoint` references remain
- [ ] Set `heartbeatPath = /health` and confirm status JSON shows the overridden URL
- [ ] Review `docs/HEARTBEAT.md` for accuracy vs notification-api route

Closes #32