### PR TITLE
feat: network latency and jitter sensors for Home Assistant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # Recent Changes Summary
 
-# Recent Changes Summary
+## Network Latency & Jitter Sensors (#30)
+
+- **Network quality metrics for Home Assistant** — multi-sample HTTP RTT probes publish **latency** and **jitter** (ms) via MQTT auto-discovery, not only DNS up/down.
+- **Configurable probe target** — set `probe_target`, `interval_ms`, `samples`, and `timeout_ms` over MQTT (`homeassistant/poop_monitor/command/network_config`); settings persist in NVS.
+- **New HA entities**: `network_latency`, `network_jitter`, `network_probe_target` (plus matching fields on the consolidated status JSON).
+- **Module**: `src/network_metrics.h/.cpp` integrated into the main loop and MQTT status/discovery path.
+- **Docs**: README entity list and configuration examples updated.
+
+---
 
 ## Unreleased
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ An ESP32-based monitoring device with **Home Assistant integration**, modern web
 - 📡 WiFi connectivity with custom DNS configuration and fallback
 - 🔄 OTA (Over-The-Air) firmware updates with **automatic rollback protection**
 - 🛡️ **Smart Boot Failure Recovery** - Automatic rollback after 10 consecutive boot failures
-- 🏠 **Home Assistant Integration** - MQTT auto-discovery with 12+ sensors and controls
-- 📊 **Real-time MQTT Publishing** - Device status, WiFi signal, DNS health, uptime tracking
+- 🏠 **Home Assistant Integration** - MQTT auto-discovery with 15+ sensors and controls
+- 📊 **Real-time MQTT Publishing** - Device status, WiFi signal, DNS health, network latency/jitter, uptime tracking
+- 📈 **Network Latency & Jitter** - Configurable HTTP probe target with HA sensors for RTT quality
 - 📋 **Live Telnet Logs in HA** - View device console output in Home Assistant
 - 🎛️ **Remote Device Control** - Reboot and alert management from Home Assistant
 - 🖥️ **Live telnet console streaming** to web interface with syntax highlighting
@@ -111,6 +112,7 @@ src/
 ├── telnet.h/.cpp         # Telnet server with MQTT log publishing
 ├── notifications.h/.cpp  # Pushover alerts
 ├── dns_manager.h/.cpp    # DNS testing
+├── network_metrics.h/.cpp # Network latency/jitter probes
 ├── ota_manager.h/.cpp    # OTA updates
 ├── system_utils.h/.cpp   # System utilities (reboot, etc.)
 ├── web_server.h/.cpp     # Web API endpoints
@@ -150,6 +152,9 @@ Once configured, these entities automatically appear in Home Assistant:
 - **WiFi Signal Strength** - Real-time signal in dBm and percentage  
 - **WiFi Quality** - Human-readable WiFi quality (Excellent/Good/Ok/Poor)
 - **DNS Connectivity** - Binary sensor showing DNS working/failed
+- **Network Latency** - Mean HTTP RTT to the configured probe target (ms)
+- **Network Jitter** - Mean absolute difference between consecutive RTT samples (ms)
+- **Network Probe Target** - Active probe URL used for latency/jitter
 - **Device Uptime** - Uptime tracking with duration device class
 - **Free Memory** - Memory usage monitoring in bytes
 - **Free Memory Percent** - Memory usage as a percentage
@@ -165,7 +170,7 @@ Once configured, these entities automatically appear in Home Assistant:
 **Features:**
 - **Availability Monitoring** - Home Assistant tracks device online/offline status
 - **Real-time Data** - Status published every 30 seconds for live monitoring
-- **Historical Graphs** - WiFi signal, uptime, memory usage over time
+- **Historical Graphs** - WiFi signal, latency/jitter, uptime, memory usage over time
 - **Automation Ready** - Use any sensor for Home Assistant automations
 
 ### MQTT Topics
@@ -177,17 +182,80 @@ The device uses standard Home Assistant discovery topics:
 - **Availability**: `homeassistant/sensor/poop_monitor/availability`
 - **Telnet Logs**: `homeassistant/sensor/poop_monitor/telnet`
 - **Commands**: `homeassistant/poop_monitor/command/*`
+  - `.../reboot`, `.../alerts`, `.../dns_config`, `.../network_config`
 
 ### Home Assistant Dashboard Example
 
 Create dashboards with:
 - Real-time WiFi signal strength graphs
+- Network latency and jitter graphs
 - DNS connectivity status indicators  
 - Device uptime and memory usage charts
 - Live telnet log display
 - Alert control switches
 - Reboot button for remote management
 - Automation triggers for device offline alerts
+
+## Network Latency & Jitter
+
+In addition to DNS up/down checks, the device measures **network quality** via multi-sample HTTP RTT probes and publishes results to Home Assistant.
+
+### What is measured
+
+| Metric | HA entity | Description |
+|--------|-----------|-------------|
+| Latency | `network_latency` | Mean round-trip time (ms) across successful samples |
+| Jitter | `network_jitter` | Mean absolute difference between consecutive sample RTTs (ms) |
+| Probe target | `network_probe_target` | Active `http://` URL used for probing |
+
+Values are also included in the consolidated status JSON (`network_latency_ms`, `network_jitter_ms`, probe config fields).
+
+### Defaults
+
+- **Probe target**: `http://httpbin.org/ip` (HTTP only — avoids TLS heap cost on ESP32-C3)
+- **Interval**: 60 seconds
+- **Samples per probe**: 4
+- **Per-request timeout**: 3000 ms
+
+Configuration is persisted in NVS (`net_metrics` namespace) and survives reboots.
+
+### Configure via MQTT
+
+Publish JSON to `homeassistant/poop_monitor/command/network_config` (omit keys you want to leave unchanged):
+
+```json
+{
+  "probe_target": "http://connectivitycheck.gstatic.com/generate_204",
+  "interval_ms": 60000,
+  "samples": 4,
+  "timeout_ms": 3000
+}
+```
+
+Rules:
+
+- `probe_target` must be a valid `http://` URL (HTTPS is rejected)
+- `interval_ms`: 10s–24h
+- `samples`: 2–10
+- `timeout_ms`: 500–15000
+- After a successful config update the device runs an immediate probe and republishes sensors
+
+### Home Assistant example
+
+```yaml
+# Alert when latency is consistently high
+automation:
+  - alias: "Poop monitor high latency"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.esp32_poop_monitor_network_latency
+        above: 500
+        for: "00:05:00"
+    action:
+      - service: notify.mobile_app
+        data:
+          message: "ESP32 network latency is high"
+```
 
 ## Smart DNS Monitoring
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@
 - Remote Log Download: Download device logs from the web UI for troubleshooting.
 
 ## Advanced Monitoring
-- Network Latency & Jitter Tracking: Monitor and report network quality, not just connectivity.
+- ~~Network Latency & Jitter Tracking: Monitor and report network quality, not just connectivity.~~ **Done (#30)** — HTTP RTT latency/jitter sensors + configurable probe target.
 - Smart Power Management: Sleep/wake cycles based on network activity or Home Assistant commands.
 - Sensor Expansion: Plug-and-play support for additional sensors (e.g., temperature, humidity, air quality).
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "telnet.h"
 #include "notifications.h"
 #include "dns_manager.h"
+#include "network_metrics.h"
 #include "ota_manager.h"
 #include "system_utils.h"
 
@@ -110,6 +111,8 @@ void setup() {
 
   // Load persisted DNS timing configuration (after preferences system ready)
   loadDNSConfigFromStorage();
+  // Load network latency/jitter probe configuration
+  loadNetworkMetricsConfigFromStorage();
 
   // Connect to WiFi
   WiFi.begin(ssid, password);
@@ -180,6 +183,9 @@ void loop() {
 #ifdef ENABLE_MQTT
   handleMQTTLoop();  // Handle MQTT connection and publishing
 #endif
+
+  // Periodic network latency/jitter probes (configurable target/interval)
+  handleNetworkMetrics();
   
   // Check for reboot flag (set by web interface)
   if (checkRebootFlag()) {

--- a/src/mqtt_manager.cpp
+++ b/src/mqtt_manager.cpp
@@ -4,8 +4,10 @@
 #include "mqtt_manager.h"
 #include "config.h"
 #include "dns_manager.h"
+#include "network_metrics.h"
 #include "system_utils.h"
 #include <WiFi.h>
+#include <math.h>
 
 // MQTT client instances
 WiFiClient wifiClientMQTT;
@@ -48,6 +50,17 @@ static void publishMetricsIndividual() {
     // DNS
     extern bool isDNSWorking;
     mqttClient.publish("homeassistant/sensor/poop_monitor/dns_status", isDNSWorking ? "ON" : "OFF", false);
+    // Network latency / jitter (HTTP RTT probe)
+    if (networkLatencyMs >= 0.0f) {
+        mqttClient.publish("homeassistant/sensor/poop_monitor/network_latency",
+                           String(networkLatencyMs, 1).c_str(), false);
+    }
+    if (networkJitterMs >= 0.0f) {
+        mqttClient.publish("homeassistant/sensor/poop_monitor/network_jitter",
+                           String(networkJitterMs, 1).c_str(), false);
+    }
+    mqttClient.publish("homeassistant/sensor/poop_monitor/network_probe_target",
+                       networkProbeTarget, false);
     // Uptime seconds
     mqttClient.publish("homeassistant/sensor/poop_monitor/uptime", String(millis() / 1000).c_str(), false);
     // Free Memory
@@ -118,7 +131,8 @@ void connectToMQTT() {
         // Subscribe to command topics
         mqttClient.subscribe((String(MQTT_COMMAND_TOPIC) + "/reboot").c_str());
         mqttClient.subscribe((String(MQTT_COMMAND_TOPIC) + "/alerts").c_str());
-    mqttClient.subscribe((String(MQTT_COMMAND_TOPIC) + "/dns_config").c_str());
+        mqttClient.subscribe((String(MQTT_COMMAND_TOPIC) + "/dns_config").c_str());
+        mqttClient.subscribe((String(MQTT_COMMAND_TOPIC) + "/network_config").c_str());
         
         // Publish that we're online
         publishAvailability(true);
@@ -161,40 +175,52 @@ void publishHomeAssistantDiscovery() {
         publishSensor("binary_sensor", "dns", "DNS", 
                   nullptr, "connectivity", MQTT_STATUS_TOPIC, "mdi:dns");
     
-    // 4. Uptime (reads from consolidated status topic)
+    // 4. Network Latency (HTTP RTT mean)
+        publishSensor("sensor", "network_latency", "Network Latency",
+                  "ms", nullptr, "homeassistant/sensor/poop_monitor/network_latency", "mdi:timer-outline");
+    
+    // 5. Network Jitter (mean absolute consecutive sample delta)
+        publishSensor("sensor", "network_jitter", "Network Jitter",
+                  "ms", nullptr, "homeassistant/sensor/poop_monitor/network_jitter", "mdi:chart-timeline-variant");
+    
+    // 6. Network Probe Target (configured URL)
+        publishSensor("sensor", "network_probe_target", "Network Probe Target",
+                  nullptr, nullptr, "homeassistant/sensor/poop_monitor/network_probe_target", "mdi:target");
+    
+    // 7. Uptime (reads from consolidated status topic)
         publishSensor("sensor", "uptime", "Uptime", 
                   "s", "duration", MQTT_STATUS_TOPIC, "mdi:clock");
     
-    // 5. Memory Usage
+    // 8. Memory Usage
         publishSensor("sensor", "free_memory", "Free Memory",
                   nullptr, nullptr, "homeassistant/sensor/poop_monitor/memory", "mdi:memory");
     
-    // 6. Last Heartbeat Success
+    // 9. Last Heartbeat Success
         publishSensor("sensor", "last_heartbeat", "Last Heartbeat",
                   nullptr, nullptr, MQTT_STATUS_TOPIC, "mdi:heart-pulse");
     
-    // 7. IP Address (reads from consolidated status topic)
+    // 10. IP Address (reads from consolidated status topic)
         publishSensor("sensor", "ip_address", "IP Address", 
                   nullptr, nullptr, MQTT_STATUS_TOPIC, "mdi:ip");
     
-    // 8. Firmware Version (reads from consolidated status topic)
+    // 11. Firmware Version (reads from consolidated status topic)
         publishSensor("sensor", "firmware", "Firmware", 
                   nullptr, nullptr, MQTT_STATUS_TOPIC, "mdi:chip");
     
-    // 9. Alerts Status (reads from consolidated status topic)
+    // 12. Alerts Status (reads from consolidated status topic)
         publishSensor("binary_sensor", "alerts", "Alerts Enabled", 
                   nullptr, nullptr, MQTT_STATUS_TOPIC, "mdi:bell");
     
-    // 10. Telnet Log Sensor
+    // 13. Telnet Log Sensor
         publishSensor("sensor", "telnet_log", "Telnet Log", 
                   nullptr, nullptr, MQTT_TELNET_TOPIC, "mdi:console");
     
-    // 11. Alert Control Switch
+    // 14. Alert Control Switch
         publishSwitch("alert_switch", "Alert Control", 
                   (String(MQTT_COMMAND_TOPIC) + "/alerts").c_str(),
                   "homeassistant/sensor/poop_monitor/alerts", "mdi:bell");
     
-    // 12. Reboot Button
+    // 15. Reboot Button
         publishButton("reboot", "Reboot", 
                   (String(MQTT_COMMAND_TOPIC) + "/reboot").c_str(), "mdi:restart");
     
@@ -245,6 +271,14 @@ void publishSensor(const char* component, const char* object_id, const char* nam
         configDoc["value_template"] = "{{ 'ON' if value_json.dns_working else 'OFF' }}";
         configDoc["payload_on"] = "ON";
         configDoc["payload_off"] = "OFF";
+    } else if (strcmp(object_id, "network_latency") == 0) {
+        configDoc["value_template"] = "{{ value | float }}";
+        configDoc["state_class"] = "measurement";
+    } else if (strcmp(object_id, "network_jitter") == 0) {
+        configDoc["value_template"] = "{{ value | float }}";
+        configDoc["state_class"] = "measurement";
+    } else if (strcmp(object_id, "network_probe_target") == 0) {
+        configDoc["value_template"] = "{{ value | default('unknown') }}";
     } else if (strcmp(object_id, "uptime") == 0) {
         configDoc["value_template"] = "{{ (value_json.uptime_ms / 1000) | round(0) }}";
     } else if (strcmp(object_id, "free_memory") == 0) {
@@ -343,6 +377,26 @@ String getDeviceStatusJSON() {
     statusDoc["last_dns_check"] = lastDNSCheck;
     if (!isDNSWorking && dnsFailureStartTime > 0) {
         statusDoc["dns_down_duration_ms"] = millis() - dnsFailureStartTime;
+    }
+
+    // Network latency / jitter (HTTP RTT multi-sample probe)
+    statusDoc["network_probe_target"] = networkProbeTarget;
+    statusDoc["network_probe_interval_ms"] = networkProbeIntervalMs;
+    statusDoc["network_probe_samples"] = networkProbeSamples;
+    statusDoc["network_probe_timeout_ms"] = networkProbeTimeoutMs;
+    statusDoc["network_probe_ok"] = networkProbeOk;
+    statusDoc["network_probe_success_count"] = networkProbeSuccessCount;
+    statusDoc["network_probe_attempt_count"] = networkProbeAttemptCount;
+    statusDoc["last_network_probe_ms"] = lastNetworkProbeMs;
+    if (networkLatencyMs >= 0.0f) {
+        statusDoc["network_latency_ms"] = roundf(networkLatencyMs * 10.0f) / 10.0f;
+    } else {
+        statusDoc["network_latency_ms"] = nullptr;
+    }
+    if (networkJitterMs >= 0.0f) {
+        statusDoc["network_jitter_ms"] = roundf(networkJitterMs * 10.0f) / 10.0f;
+    } else {
+        statusDoc["network_jitter_ms"] = nullptr;
     }
     
     // Heartbeat info (using external variables)
@@ -552,6 +606,25 @@ void onMQTTMessage(char* topic, byte* payload, unsigned int length) {
         extern void updateDNSConfig(unsigned long, unsigned long, unsigned long, unsigned long);
         updateDNSConfig(failure, interval, recovery, minRec);
         // Publish updated status after change
+        delay(50);
+        publishAllSensors();
+    }
+    // Handle network latency/jitter probe config (expects JSON)
+    else if (topicStr == String(MQTT_COMMAND_TOPIC) + "/network_config") {
+        // Optional keys: probe_target, interval_ms, samples, timeout_ms
+        JsonDocument doc;
+        DeserializationError err = deserializeJson(doc, message);
+        if (err) {
+            Serial.printf("Invalid network config JSON: %s\n", err.c_str());
+            return;
+        }
+        const char* target = doc["probe_target"] | "";
+        unsigned long interval = doc["interval_ms"] | 0UL;
+        uint8_t samples = (uint8_t)(doc["samples"] | 0);
+        unsigned long timeout = doc["timeout_ms"] | 0UL;
+        updateNetworkMetricsConfig(target, interval, samples, timeout);
+        // Run an immediate probe with the new settings so HA sees fresh values
+        probeNetworkQuality();
         delay(50);
         publishAllSensors();
     }

--- a/src/network_metrics.cpp
+++ b/src/network_metrics.cpp
@@ -1,0 +1,280 @@
+#include "network_metrics.h"
+#include "config.h"
+#include "telnet.h"
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <Preferences.h>
+#include <math.h>
+#include <string.h>
+
+// Defaults: lightweight public HTTP endpoint used for connectivity checks
+const char* NETWORK_DEFAULT_PROBE_TARGET = "http://httpbin.org/ip";
+const unsigned long NETWORK_DEFAULT_PROBE_INTERVAL_MS = 60UL * 1000UL;  // 60s
+const uint8_t NETWORK_DEFAULT_PROBE_SAMPLES = 4;
+const unsigned long NETWORK_DEFAULT_PROBE_TIMEOUT_MS = 3000UL;
+
+char networkProbeTarget[128];
+unsigned long networkProbeIntervalMs = NETWORK_DEFAULT_PROBE_INTERVAL_MS;
+uint8_t networkProbeSamples = NETWORK_DEFAULT_PROBE_SAMPLES;
+unsigned long networkProbeTimeoutMs = NETWORK_DEFAULT_PROBE_TIMEOUT_MS;
+
+float networkLatencyMs = -1.0f;
+float networkJitterMs = -1.0f;
+unsigned long lastNetworkProbeMs = 0;
+bool networkProbeOk = false;
+uint8_t networkProbeSuccessCount = 0;
+uint8_t networkProbeAttemptCount = 0;
+
+static bool configLoaded = false;
+
+static void setDefaultProbeTarget() {
+  strncpy(networkProbeTarget, NETWORK_DEFAULT_PROBE_TARGET, sizeof(networkProbeTarget) - 1);
+  networkProbeTarget[sizeof(networkProbeTarget) - 1] = '\0';
+}
+
+static bool isValidHttpUrl(const char* url) {
+  if (url == nullptr || url[0] == '\0') return false;
+  size_t len = strlen(url);
+  if (len < 10 || len >= sizeof(networkProbeTarget)) return false;
+  // Only allow http:// to avoid TLS heap pressure on ESP32-C3 for background probes
+  if (strncmp(url, "http://", 7) != 0) return false;
+  // Basic sanity: host present after scheme
+  if (url[7] == '\0' || url[7] == '/') return false;
+  // Reject characters that break HTTPClient / storage
+  for (size_t i = 0; i < len; i++) {
+    char c = url[i];
+    if (c < 32 || c > 126) return false;
+    if (c == ' ' || c == '"' || c == '\'' || c == '\\') return false;
+  }
+  return true;
+}
+
+void loadNetworkMetricsConfigFromStorage() {
+  if (configLoaded) return;
+
+  setDefaultProbeTarget();
+  networkProbeIntervalMs = NETWORK_DEFAULT_PROBE_INTERVAL_MS;
+  networkProbeSamples = NETWORK_DEFAULT_PROBE_SAMPLES;
+  networkProbeTimeoutMs = NETWORK_DEFAULT_PROBE_TIMEOUT_MS;
+
+  Preferences prefs;
+  if (!prefs.begin("net_metrics", true)) {
+    Serial.println("[NET] No stored network metrics config, using defaults");
+    configLoaded = true;
+    return;
+  }
+
+  String target = prefs.getString("probe_tgt", NETWORK_DEFAULT_PROBE_TARGET);
+  unsigned long interval = prefs.getULong("interval", NETWORK_DEFAULT_PROBE_INTERVAL_MS);
+  uint8_t samples = (uint8_t)prefs.getUChar("samples", NETWORK_DEFAULT_PROBE_SAMPLES);
+  unsigned long timeout = prefs.getULong("timeout", NETWORK_DEFAULT_PROBE_TIMEOUT_MS);
+  prefs.end();
+
+  if (isValidHttpUrl(target.c_str())) {
+    strncpy(networkProbeTarget, target.c_str(), sizeof(networkProbeTarget) - 1);
+    networkProbeTarget[sizeof(networkProbeTarget) - 1] = '\0';
+  } else {
+    setDefaultProbeTarget();
+  }
+
+  const unsigned long MAX_INTERVAL = 24UL * 60UL * 60UL * 1000UL;
+  if (interval >= 10000UL && interval <= MAX_INTERVAL) {
+    networkProbeIntervalMs = interval;
+  }
+  if (samples >= 2 && samples <= 10) {
+    networkProbeSamples = samples;
+  }
+  if (timeout >= 500UL && timeout <= 15000UL) {
+    networkProbeTimeoutMs = timeout;
+  }
+
+  configLoaded = true;
+  Serial.printf("[NET] Loaded config: target=%s interval=%lu ms samples=%u timeout=%lu ms\r\n",
+                networkProbeTarget, networkProbeIntervalMs, networkProbeSamples, networkProbeTimeoutMs);
+}
+
+void saveNetworkMetricsConfigToStorage() {
+  Preferences prefs;
+  if (!prefs.begin("net_metrics", false)) {
+    Serial.println("[NET] Failed to open NVS for network metrics save");
+    return;
+  }
+  prefs.putString("probe_tgt", networkProbeTarget);
+  prefs.putULong("interval", networkProbeIntervalMs);
+  prefs.putUChar("samples", networkProbeSamples);
+  prefs.putULong("timeout", networkProbeTimeoutMs);
+  prefs.end();
+  Serial.println("[NET] Network metrics config saved to NVS");
+}
+
+void updateNetworkMetricsConfig(const char* probeTarget,
+                                unsigned long intervalMs,
+                                uint8_t samples,
+                                unsigned long timeoutMs) {
+  bool changed = false;
+  const unsigned long MAX_INTERVAL = 24UL * 60UL * 60UL * 1000UL;
+
+  if (probeTarget != nullptr && probeTarget[0] != '\0') {
+    if (isValidHttpUrl(probeTarget)) {
+      if (strncmp(networkProbeTarget, probeTarget, sizeof(networkProbeTarget)) != 0) {
+        strncpy(networkProbeTarget, probeTarget, sizeof(networkProbeTarget) - 1);
+        networkProbeTarget[sizeof(networkProbeTarget) - 1] = '\0';
+        changed = true;
+      }
+    } else {
+      Serial.printf("[NET] Rejected invalid probe target: %s\r\n", probeTarget);
+    }
+  }
+
+  if (intervalMs != 0) {
+    if (intervalMs >= 10000UL && intervalMs <= MAX_INTERVAL) {
+      if (intervalMs != networkProbeIntervalMs) {
+        networkProbeIntervalMs = intervalMs;
+        changed = true;
+      }
+    } else {
+      Serial.printf("[NET] Rejected invalid interval_ms: %lu\r\n", intervalMs);
+    }
+  }
+
+  if (samples != 0) {
+    if (samples >= 2 && samples <= 10) {
+      if (samples != networkProbeSamples) {
+        networkProbeSamples = samples;
+        changed = true;
+      }
+    } else {
+      Serial.printf("[NET] Rejected invalid samples: %u\r\n", samples);
+    }
+  }
+
+  if (timeoutMs != 0) {
+    if (timeoutMs >= 500UL && timeoutMs <= 15000UL) {
+      if (timeoutMs != networkProbeTimeoutMs) {
+        networkProbeTimeoutMs = timeoutMs;
+        changed = true;
+      }
+    } else {
+      Serial.printf("[NET] Rejected invalid timeout_ms: %lu\r\n", timeoutMs);
+    }
+  }
+
+  if (changed) {
+    Serial.printf("[NET] Updated config: target=%s interval=%lu ms samples=%u timeout=%lu ms\r\n",
+                  networkProbeTarget, networkProbeIntervalMs, networkProbeSamples, networkProbeTimeoutMs);
+    saveNetworkMetricsConfigToStorage();
+  } else {
+    Serial.println("[NET] updateNetworkMetricsConfig called but no values changed");
+  }
+}
+
+// Single HTTP RTT sample in milliseconds; returns -1 on failure
+static float measureHttpRttMs(const char* url) {
+  WiFiClient client;
+  HTTPClient http;
+
+  unsigned long start = millis();
+  if (!http.begin(client, url)) {
+    return -1.0f;
+  }
+  http.setTimeout((int)networkProbeTimeoutMs);
+  http.setReuse(false);
+
+  int code = http.GET();
+  unsigned long elapsed = millis() - start;
+  http.end();
+
+  // Any completed HTTP exchange counts for latency (including 4xx/5xx);
+  // connection/timeout failures return negative codes from HTTPClient.
+  if (code > 0) {
+    return (float)elapsed;
+  }
+  return -1.0f;
+}
+
+bool probeNetworkQuality() {
+  if (WiFi.status() != WL_CONNECTED) {
+    networkProbeOk = false;
+    return false;
+  }
+
+  if (networkProbeTarget[0] == '\0') {
+    setDefaultProbeTarget();
+  }
+
+  const uint8_t n = networkProbeSamples;
+  float samples[10];
+  uint8_t okCount = 0;
+
+  Serial.printf("[%10lu ms] [NET] Probing latency/jitter target=%s samples=%u\r\n",
+                millis(), networkProbeTarget, n);
+
+  for (uint8_t i = 0; i < n && i < 10; i++) {
+    float rtt = measureHttpRttMs(networkProbeTarget);
+    networkProbeAttemptCount = i + 1;
+    if (rtt >= 0.0f) {
+      samples[okCount++] = rtt;
+      Serial.printf("[%10lu ms] [NET] Sample %u: %.0f ms\r\n", millis(), i + 1, rtt);
+    } else {
+      Serial.printf("[%10lu ms] [NET] Sample %u: failed\r\n", millis(), i + 1);
+    }
+    // Small gap between samples to avoid hammering the target
+    if (i + 1 < n) {
+      delay(50);
+    }
+  }
+
+  networkProbeSuccessCount = okCount;
+  lastNetworkProbeMs = millis();
+
+  if (okCount == 0) {
+    networkProbeOk = false;
+    networkLatencyMs = -1.0f;
+    networkJitterMs = -1.0f;
+    Serial.printf("[%10lu ms] [NET] Probe failed — no successful samples\r\n", millis());
+    return false;
+  }
+
+  // Mean latency
+  float sum = 0.0f;
+  for (uint8_t i = 0; i < okCount; i++) {
+    sum += samples[i];
+  }
+  networkLatencyMs = sum / (float)okCount;
+
+  // Jitter: mean absolute difference between consecutive successful samples
+  if (okCount >= 2) {
+    float jsum = 0.0f;
+    for (uint8_t i = 1; i < okCount; i++) {
+      jsum += fabsf(samples[i] - samples[i - 1]);
+    }
+    networkJitterMs = jsum / (float)(okCount - 1);
+  } else {
+    networkJitterMs = 0.0f;
+  }
+
+  networkProbeOk = true;
+  Serial.printf("[%10lu ms] [NET] Latency=%.1f ms Jitter=%.1f ms (%u/%u samples)\r\n",
+                millis(), networkLatencyMs, networkJitterMs, okCount, n);
+  return true;
+}
+
+void handleNetworkMetrics() {
+  if (!configLoaded) {
+    loadNetworkMetricsConfigFromStorage();
+  }
+
+  if (WiFi.status() != WL_CONNECTED) {
+    return;
+  }
+
+  unsigned long now = millis();
+  // First run soon after boot (after 5s), then on interval
+  bool due = (lastNetworkProbeMs == 0)
+             ? (now >= 5000UL)
+             : ((now - lastNetworkProbeMs) >= networkProbeIntervalMs);
+
+  if (due) {
+    probeNetworkQuality();
+  }
+}

--- a/src/network_metrics.h
+++ b/src/network_metrics.h
@@ -1,0 +1,43 @@
+#ifndef NETWORK_METRICS_H
+#define NETWORK_METRICS_H
+
+#include <Arduino.h>
+
+// Default probe target (lightweight HTTP endpoint; override via MQTT/NVS)
+extern const char* NETWORK_DEFAULT_PROBE_TARGET;
+extern const unsigned long NETWORK_DEFAULT_PROBE_INTERVAL_MS;
+extern const uint8_t NETWORK_DEFAULT_PROBE_SAMPLES;
+extern const unsigned long NETWORK_DEFAULT_PROBE_TIMEOUT_MS;
+
+// Runtime configuration
+extern char networkProbeTarget[128];
+extern unsigned long networkProbeIntervalMs;
+extern uint8_t networkProbeSamples;
+extern unsigned long networkProbeTimeoutMs;
+
+// Latest measurements (-1 means unknown / no successful sample yet)
+extern float networkLatencyMs;
+extern float networkJitterMs;
+extern unsigned long lastNetworkProbeMs;
+extern bool networkProbeOk;
+extern uint8_t networkProbeSuccessCount;
+extern uint8_t networkProbeAttemptCount;
+
+// Lifecycle
+void loadNetworkMetricsConfigFromStorage();
+void saveNetworkMetricsConfigToStorage();
+
+// Update config; empty/null probeTarget leaves target unchanged; 0 leaves numeric fields unchanged
+void updateNetworkMetricsConfig(const char* probeTarget,
+                                unsigned long intervalMs,
+                                uint8_t samples,
+                                unsigned long timeoutMs);
+
+// Run a multi-sample HTTP RTT probe; updates latency/jitter globals
+// Returns true if at least one sample succeeded
+bool probeNetworkQuality();
+
+// Call from main loop — probes on interval when WiFi is up
+void handleNetworkMetrics();
+
+#endif


### PR DESCRIPTION
## Summary
Implements network quality metrics (latency/jitter) for Home Assistant via MQTT auto-discovery, beyond DNS up/down connectivity.

## Changes
- New `src/network_metrics.h/.cpp` module: multi-sample HTTP RTT probes
- HA entities: **Network Latency**, **Network Jitter**, **Network Probe Target**
- Configurable via MQTT `homeassistant/poop_monitor/command/network_config` (target, interval, samples, timeout); persisted in NVS
- Status JSON includes `network_latency_ms`, `network_jitter_ms`, and probe config fields
- README entity list + configuration docs; CHANGES.md; ROADMAP item marked done

## Acceptance criteria
- [x] MQTT/HA entities for latency/jitter
- [x] Configurable probe target
- [x] Docs + entity list updated

## Validation
- `pio run --environment esp32-c3-devkitm-1` succeeded (MQTT-only build)

Closes #30
