### PR TITLE
fix: credentials vs config flash path is easy to misconfigure (#33)

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -24,28 +24,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bc
       - uses: n-vr/setup-platformio-action@v1
-      - name: Create dummy credentials
+      - name: Create dummy credentials from template
         run: |
-          cat <<'EOF' > src/credentials.h
-          #pragma once
-          extern const char* WIFI_SSID;
-          extern const char* WIFI_PASSWORD;
-          extern const char* OTA_PASSWORD;
-          extern const char* PUSHOVER_TOKEN;
-          extern const char* PUSHOVER_USER;
-          extern const char* MQTT_USER;
-          extern const char* MQTT_PASSWORD;
-          EOF
-          cat <<'EOF' > src/credentials.cpp
-          #include "credentials.h"
-          const char* WIFI_SSID = "";
-          const char* WIFI_PASSWORD = "";
-          const char* OTA_PASSWORD = "";
-          const char* PUSHOVER_TOKEN = "";
-          const char* PUSHOVER_USER = "";
-          const char* MQTT_USER = "";
-          const char* MQTT_PASSWORD = "";
-          EOF
+          # Compile-time credential macros come from credentials_private.h
+          # (see credentials.template.h). CI never uses real secrets.
+          cp credentials.template.h src/credentials_private.h
       - name: Build all firmware configurations
         id: build
         run: |
@@ -100,27 +83,13 @@ jobs:
           if git checkout main 2>/dev/null; then
             echo "Building main branch for comparison..."
             
-            # Create dummy credentials for main branch build
-            cat <<'EOF' > src/credentials.h
-          #pragma once
-          extern const char* WIFI_SSID;
-          extern const char* WIFI_PASSWORD;
-          extern const char* OTA_PASSWORD;
-          extern const char* PUSHOVER_TOKEN;
-          extern const char* PUSHOVER_USER;
-          extern const char* MQTT_USER;
-          extern const char* MQTT_PASSWORD;
-          EOF
-            cat <<'EOF' > src/credentials.cpp
-          #include "credentials.h"
-          const char* WIFI_SSID = "";
-          const char* WIFI_PASSWORD = "";
-          const char* OTA_PASSWORD = "";
-          const char* PUSHOVER_TOKEN = "";
-          const char* PUSHOVER_USER = "";
-          const char* MQTT_USER = "";
-          const char* MQTT_PASSWORD = "";
-          EOF
+            # Dummy credentials for main branch comparison build
+            if [ -f credentials.template.h ]; then
+              cp credentials.template.h src/credentials_private.h
+            elif [ -f credentials.template.cpp ]; then
+              # Legacy main: credentials.cpp + header externs
+              cp credentials.template.cpp src/credentials.cpp 2>/dev/null || true
+            fi
             
             # Build main branch (try both old and new format)
             if pio run 2>/dev/null | tee main-build.log; then

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ libraries/*
 !libraries/README.md
 
 # Sensitive configuration (credentials should NEVER be committed)
+# Copy credentials.template.h → src/credentials_private.h and fill in secrets.
+src/credentials_private.h
 src/credentials.cpp
 
 # Environment specific files
@@ -74,3 +76,4 @@ yarn-error.log*
 /data/*.gz
 /data/**/*.gz
 credentials.cpp
+credentials_private.h

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ An ESP32-based monitoring device with **Home Assistant integration**, modern web
 - **Improved Memory Reporting** - Free memory now shown as both formatted string and percent (`free_memory_percent`).
 - **Last Heartbeat MQTT State** - Home Assistant now receives a formatted uptime for the last heartbeat.
 - **Enhanced MQTT Metrics** - More detailed and human-friendly metrics for Home Assistant.
-- **CI/CD Improvements** - GitHub Actions workflow for build/tag automation and CI credentials template.
-- **Credentials Header** - Added `src/credentials.h` for standardized credential imports.
+- **CI/CD Improvements** - GitHub Actions workflow for build/tag automation; CI copies `credentials.template.h` for dummy secrets.
+- **Credentials split** - Secrets in gitignored `credentials_private.h` with compile-time macro checks; non-secrets in `config.cpp`.
 - **Bug Fixes** - JSON escape padding, reboot flag storage, and cache-bust emoji.
 
 ---
@@ -53,9 +53,8 @@ An ESP32-based monitoring device with **Home Assistant integration**, modern web
 - 📡 WiFi connectivity with custom DNS configuration and fallback
 - 🔄 OTA (Over-The-Air) firmware updates with **automatic rollback protection**
 - 🛡️ **Smart Boot Failure Recovery** - Automatic rollback after 10 consecutive boot failures
-- 🏠 **Home Assistant Integration** - MQTT auto-discovery with 15+ sensors and controls
-- 📊 **Real-time MQTT Publishing** - Device status, WiFi signal, DNS health, network latency/jitter, uptime tracking
-- 📈 **Network Latency & Jitter** - Configurable HTTP probe target with HA sensors for RTT quality
+- 🏠 **Home Assistant Integration** - MQTT auto-discovery with 12+ sensors and controls
+- 📊 **Real-time MQTT Publishing** - Device status, WiFi signal, DNS health, uptime tracking
 - 📋 **Live Telnet Logs in HA** - View device console output in Home Assistant
 - 🎛️ **Remote Device Control** - Reboot and alert management from Home Assistant
 - 🖥️ **Live telnet console streaming** to web interface with syntax highlighting
@@ -70,53 +69,72 @@ An ESP32-based monitoring device with **Home Assistant integration**, modern web
 
 ## Configuration Setup
 
-**Simple Setup**: All configuration is now in `src/config.cpp` - no separate credentials files needed!
+Secrets and non-secret config are **split on purpose** so you do not flash a device with the wrong (or empty) credential path.
 
-### Edit Configuration
+| What | Where | Git |
+|------|--------|-----|
+| **Secrets** (WiFi, OTA password, Pushover, MQTT auth) | `src/credentials_private.h` | **gitignored** — never commit |
+| **Non-secrets** (device name, MQTT host/port, DNS, API URLs) | `src/config.cpp` | committed |
 
-Edit `src/config.cpp` with your actual values:
+### 1. Create private credentials (required)
 
-```cpp
-// WiFi Configuration
-const char* ssid = "YOUR_WIFI_SSID";
-const char* password = "YOUR_WIFI_PASSWORD";
-
-// Heartbeat / notification-api (see docs/HEARTBEAT.md)
-// Default resolves to {base}/heartbeat/{deviceId}
-const char* heartbeatBaseUrl = "http://notifications.example.com"; // no trailing slash
-const char* heartbeatDeviceId = "poop";           // notification-api path segment
-const char* heartbeatPath = "";                   // or "/health" for a generic probe
-
-// OTA Configuration  
-const char* otaPassword = "YOUR_OTA_PASSWORD";
-
-// Pushover Configuration
-const char* pushoverToken = "YOUR_PUSHOVER_APP_TOKEN";
-const char* pushoverUser = "YOUR_PUSHOVER_USER_KEY";
-
-// MQTT Configuration (for Home Assistant)
-const char* mqttServer = "192.168.1.100";      // Your MQTT broker IP
-const int mqttPort = 1883;                     // MQTT port
-const char* mqttUser = "";                     // MQTT username (empty if no auth)
-const char* mqttPassword = "";                 // MQTT password (empty if no auth)
+```bash
+# From the repo root
+cp credentials.template.h src/credentials_private.h
+# Then edit src/credentials_private.h and replace every YOUR_* value
 ```
 
-**Heartbeat URL** is no longer a single hard-coded path: set `heartbeatBaseUrl` + `heartbeatDeviceId`, or set `heartbeatPath` (e.g. `"/health"`) for a generic health endpoint. Full contract: [`docs/HEARTBEAT.md`](docs/HEARTBEAT.md).
+PowerShell:
+
+```powershell
+Copy-Item credentials.template.h src/credentials_private.h
+# Edit src/credentials_private.h — fill in YOUR_* placeholders
+```
+
+`src/credentials.h` enforces the required macros at **compile time** (`#error` if any are missing). CI copies the same template with dummy values so PRs build without real secrets.
+
+Example `src/credentials_private.h`:
+
+```cpp
+#pragma once
+#define WIFI_SSID       "MyNetwork"
+#define WIFI_PASSWORD   "secret"
+#define OTA_PASSWORD    "ota-secret"
+#define PUSHOVER_TOKEN  "app-token"
+#define PUSHOVER_USER   "user-key"
+#define MQTT_USER       "mqtt-user"   // or ""
+#define MQTT_PASSWORD   "mqtt-pass"   // or ""
+```
+
+### 2. Edit non-secret config
+
+Edit `src/config.cpp` for broker host, DNS, device name, etc.:
+
+```cpp
+const char* mqttServer = "192.168.1.100";  // MQTT broker IP or hostname
+const int mqttPort = 1883;
+const char* deviceName = "poop-monitor";
+// DNS, API endpoint, etc.
+```
+
+Do **not** put WiFi passwords or tokens in `config.cpp` — they belong in `credentials_private.h`.
 
 ### File Structure
 
 ```
+credentials.template.h    # Template → copy to src/credentials_private.h
 src/
-├── main.cpp              # Main program
-├── config.h/.cpp         # All configuration (WiFi, MQTT, Pushover, etc.)
-├── telnet.h/.cpp         # Telnet server with MQTT log publishing
-├── notifications.h/.cpp  # Pushover alerts
-├── dns_manager.h/.cpp    # DNS testing
-├── network_metrics.h/.cpp # Network latency/jitter probes
-├── ota_manager.h/.cpp    # OTA updates
-├── system_utils.h/.cpp   # System utilities (reboot, etc.)
-├── web_server.h/.cpp     # Web API endpoints
-└── mqtt_manager.h/.cpp   # MQTT & Home Assistant integration
+├── main.cpp
+├── credentials.h         # Compile-time checks; includes credentials_private.h
+├── credentials_private.h # YOUR secrets (gitignored; not in repo)
+├── config.h/.cpp         # Non-secret config + wires credential macros
+├── telnet.h/.cpp
+├── notifications.h/.cpp
+├── dns_manager.h/.cpp
+├── ota_manager.h/.cpp
+├── system_utils.h/.cpp
+├── web_server.h/.cpp
+└── mqtt_manager.h/.cpp
 ```
 
 ## Home Assistant Integration
@@ -139,9 +157,9 @@ To get MQTT working with Home Assistant:
    - Create a username/password or leave empty for no authentication
 
 3. **Update ESP32 Config**:
-   - Set `mqttServer` to your Home Assistant IP address
-   - Set `mqttUser` and `mqttPassword` if you configured authentication
-   - Leave `mqttUser` and `mqttPassword` empty (`""`) if no authentication
+   - Set `mqttServer` / `mqttPort` in `src/config.cpp` to your Home Assistant broker
+   - Set `MQTT_USER` / `MQTT_PASSWORD` in `src/credentials_private.h` if the broker requires auth
+   - Use `#define MQTT_USER ""` and `#define MQTT_PASSWORD ""` if no authentication
 
 ### Home Assistant Entities
 
@@ -152,9 +170,6 @@ Once configured, these entities automatically appear in Home Assistant:
 - **WiFi Signal Strength** - Real-time signal in dBm and percentage  
 - **WiFi Quality** - Human-readable WiFi quality (Excellent/Good/Ok/Poor)
 - **DNS Connectivity** - Binary sensor showing DNS working/failed
-- **Network Latency** - Mean HTTP RTT to the configured probe target (ms)
-- **Network Jitter** - Mean absolute difference between consecutive RTT samples (ms)
-- **Network Probe Target** - Active probe URL used for latency/jitter
 - **Device Uptime** - Uptime tracking with duration device class
 - **Free Memory** - Memory usage monitoring in bytes
 - **Free Memory Percent** - Memory usage as a percentage
@@ -170,7 +185,7 @@ Once configured, these entities automatically appear in Home Assistant:
 **Features:**
 - **Availability Monitoring** - Home Assistant tracks device online/offline status
 - **Real-time Data** - Status published every 30 seconds for live monitoring
-- **Historical Graphs** - WiFi signal, latency/jitter, uptime, memory usage over time
+- **Historical Graphs** - WiFi signal, uptime, memory usage over time
 - **Automation Ready** - Use any sensor for Home Assistant automations
 
 ### MQTT Topics
@@ -182,13 +197,11 @@ The device uses standard Home Assistant discovery topics:
 - **Availability**: `homeassistant/sensor/poop_monitor/availability`
 - **Telnet Logs**: `homeassistant/sensor/poop_monitor/telnet`
 - **Commands**: `homeassistant/poop_monitor/command/*`
-  - `.../reboot`, `.../alerts`, `.../dns_config`, `.../network_config`
 
 ### Home Assistant Dashboard Example
 
 Create dashboards with:
 - Real-time WiFi signal strength graphs
-- Network latency and jitter graphs
 - DNS connectivity status indicators  
 - Device uptime and memory usage charts
 - Live telnet log display
@@ -196,85 +209,9 @@ Create dashboards with:
 - Reboot button for remote management
 - Automation triggers for device offline alerts
 
-## Network Latency & Jitter
-
-In addition to DNS up/down checks, the device measures **network quality** via multi-sample HTTP RTT probes and publishes results to Home Assistant.
-
-### What is measured
-
-| Metric | HA entity | Description |
-|--------|-----------|-------------|
-| Latency | `network_latency` | Mean round-trip time (ms) across successful samples |
-| Jitter | `network_jitter` | Mean absolute difference between consecutive sample RTTs (ms) |
-| Probe target | `network_probe_target` | Active `http://` URL used for probing |
-
-Values are also included in the consolidated status JSON (`network_latency_ms`, `network_jitter_ms`, probe config fields).
-
-### Defaults
-
-- **Probe target**: `http://httpbin.org/ip` (HTTP only — avoids TLS heap cost on ESP32-C3)
-- **Interval**: 60 seconds
-- **Samples per probe**: 4
-- **Per-request timeout**: 3000 ms
-
-Configuration is persisted in NVS (`net_metrics` namespace) and survives reboots.
-
-### Configure via MQTT
-
-Publish JSON to `homeassistant/poop_monitor/command/network_config` (omit keys you want to leave unchanged):
-
-```json
-{
-  "probe_target": "http://connectivitycheck.gstatic.com/generate_204",
-  "interval_ms": 60000,
-  "samples": 4,
-  "timeout_ms": 3000
-}
-```
-
-Rules:
-
-- `probe_target` must be a valid `http://` URL (HTTPS is rejected)
-- `interval_ms`: 10s–24h
-- `samples`: 2–10
-- `timeout_ms`: 500–15000
-- After a successful config update the device runs an immediate probe and republishes sensors
-
-### Home Assistant example
-
-```yaml
-# Alert when latency is consistently high
-automation:
-  - alias: "Poop monitor high latency"
-    trigger:
-      - platform: numeric_state
-        entity_id: sensor.esp32_poop_monitor_network_latency
-        above: 500
-        for: "00:05:00"
-    action:
-      - service: notify.mobile_app
-        data:
-          message: "ESP32 network latency is high"
-```
-
 ## Smart DNS Monitoring
 
 The ESP32 features intelligent DNS monitoring with configurable alerting to prevent notification spam while ensuring you're informed of important network issues.
-
-### Recommended DNS topology
-
-Configure **two different** resolvers in `src/config.cpp` (`primaryDNS` and `fallbackDNS`):
-
-| Role | Recommendation | Example |
-|------|----------------|---------|
-| **Primary** | Local recursive or filtering DNS on your LAN | Pi-hole / AdGuard (`192.168.x.x`) |
-| **Fallback** | A second, independent resolver | Another local DNS host, or a public resolver (`1.1.1.1`, `8.8.8.8`, router DNS) |
-
-- Fallback only helps when it is **not** the same IP as primary. Identical values disable meaningful failover (the firmware treats that as a single server and skips critical dual-failure alerts).
-- Prefer a local primary for filtering/latency, and a distinct fallback so brief primary outages do not take the device fully offline.
-- Sample defaults use a local primary example and Cloudflare (`1.1.1.1`) as fallback — replace both with addresses that match your network.
-
-At boot, if primary and fallback are equal, the serial/telnet log emits a **WARNING** that fallback is a no-op.
 
 ### Key Features
 
@@ -484,9 +421,10 @@ deploy-ota -Environment esp32-c3-devkitm-1-both
 
 ### Quick Start
 
-1. **Configure device**: Edit `src/config.cpp` with your WiFi, MQTT, and other settings
-2. **Build and upload**: `pio-upload-ota` (or `./upload_and_monitor.sh`)
-3. **Access device**: 
+1. **Secrets**: `cp credentials.template.h src/credentials_private.h` and fill in WiFi/OTA/Pushover/MQTT auth
+2. **Non-secrets**: Edit `src/config.cpp` (MQTT host, DNS, device name, etc.)
+3. **Build and upload**: `pio-upload-ota` (or `./upload_and_monitor.sh`)
+4. **Access device**:
    - **MQTT-only**: Home Assistant auto-discovery
    - **WebServer/Both**: `http://poop-monitor.local/`
 
@@ -558,12 +496,13 @@ curl http://poop-monitor.local/status | python3 -m json.tool
 **Build and deployment issues:**
 
 - Use `./upload_and_monitor.sh` for complete build-to-monitoring workflow
-- Check that all configuration values in `src/config.cpp` are set correctly
+- If the compiler reports `Missing WIFI_SSID` (or similar): copy `credentials.template.h` → `src/credentials_private.h` and set every macro
+- Non-secret settings (MQTT host, DNS) live in `src/config.cpp`; secrets must not
 
 
 ## Development & CI
 
-- **GitHub Actions Workflow:** Automated build and tag for releases, with CI credentials template for safe builds.
+- **GitHub Actions Workflow:** Automated build and tag for releases; builds use `credentials.template.h` as dummy secrets (never real credentials).
 - **🤖 Smart Version Tagging:** Intelligent semantic versioning based on commit analysis and PR content.
   - Analyzes changes to determine appropriate version increments (major/minor/patch)
   - Automatically updates `src/config.cpp` and `README.md` with new versions
@@ -593,8 +532,8 @@ force-version "2.5.0"  # Force specific version
 
 ## Security Notes
 
-- Store sensitive values in `src/config.cpp` - consider using environment variables
-- Use strong passwords for OTA updates and MQTT authentication  
+- Store secrets only in `src/credentials_private.h` (gitignored); never commit real tokens/passwords
+- Keep non-secret config in `src/config.cpp`
+- Use strong passwords for OTA updates and MQTT authentication
 - Consider using WPA3 for WiFi if available
-- Pushover tokens should be kept secret
 - MQTT credentials should match your Home Assistant MQTT user configuration

--- a/credentials.template.cpp
+++ b/credentials.template.cpp
@@ -1,23 +1,14 @@
-#include "src/credentials.h"
-
-// INSTRUCTIONS:
-// 1. Copy this file to src/credentials.cpp
-// 2. Fill in your actual values
-// 3. credentials.cpp is in .gitignore so your secrets won't be committed
-
-// WiFi Configuration
-const char* WIFI_SSID = "YOUR_WIFI_SSID";
-const char* WIFI_PASSWORD = "YOUR_WIFI_PASSWORD";
-
-// OTA Configuration  
-const char* OTA_PASSWORD = "YOUR_OTA_PASSWORD";
-
-// Pushover Configuration
-const char* PUSHOVER_TOKEN = "YOUR_PUSHOVER_APP_TOKEN";
-const char* PUSHOVER_USER = "YOUR_PUSHOVER_USER_KEY";
-
-// MQTT Configuration
-const char* MQTT_SERVER = "YOUR_MQTT_SERVER_IP";      // e.g., "192.168.1.100"
-const int MQTT_PORT = 1883;                           // Default MQTT port (1883 or 8883 for SSL)
-const char* MQTT_USER = "YOUR_MQTT_USERNAME";         // Can be "" if no auth required
-const char* MQTT_PASSWORD = "YOUR_MQTT_PASSWORD";     // Can be "" if no auth required
+// DEPRECATED: use credentials.template.h instead.
+//
+// Previous flow (no longer used by the build):
+//   copy credentials.template.cpp → src/credentials.cpp
+//
+// Current flow:
+//   1. Copy credentials.template.h → src/credentials_private.h
+//   2. Fill in YOUR_* placeholders
+//   3. Secrets are compile-time macros checked in src/credentials.h
+//
+// Non-secret settings (MQTT host, DNS, device name, etc.) remain in
+// src/config.cpp. Do not put WiFi/OTA/Pushover/MQTT passwords there.
+//
+// This file is kept only so existing docs/links do not 404; it is not compiled.

--- a/credentials.template.h
+++ b/credentials.template.h
@@ -1,0 +1,32 @@
+// =============================================================================
+// Credentials template (secrets) — DO NOT put real secrets in git
+// =============================================================================
+//
+// Setup:
+//   1. Copy this file to:  src/credentials_private.h
+//   2. Replace every YOUR_* placeholder with your real values
+//   3. Build / flash as usual (pio run, upload_and_monitor.sh, etc.)
+//
+// src/credentials_private.h is gitignored. Non-secret settings (device name,
+// MQTT broker host, DNS, API URLs, feature flags) stay in src/config.cpp.
+//
+// CI copies this template automatically so firmware still compiles without
+// real secrets.
+// =============================================================================
+
+#pragma once
+
+// WiFi
+#define WIFI_SSID       "YOUR_WIFI_SSID"
+#define WIFI_PASSWORD   "YOUR_WIFI_PASSWORD"
+
+// OTA password (must match upload_flags --auth in platformio.ini for OTA)
+#define OTA_PASSWORD    "YOUR_OTA_PASSWORD"
+
+// Pushover (https://pushover.net)
+#define PUSHOVER_TOKEN  "YOUR_PUSHOVER_APP_TOKEN"
+#define PUSHOVER_USER   "YOUR_PUSHOVER_USER_KEY"
+
+// MQTT auth (use "" for both if the broker allows anonymous)
+#define MQTT_USER       "YOUR_MQTT_USERNAME"
+#define MQTT_PASSWORD   "YOUR_MQTT_PASSWORD"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,57 +1,28 @@
 #include "config.h"
-#include "credentials.h"
-#include <cstdio>
+#include "credentials.h"  // secrets: src/credentials_private.h (from credentials.template.h)
 
 const char* firmwareVersion = "2.9.0";
 
-// WiFi Configuration (from credentials.h)
+// --- Secrets (from credentials macros; never commit real values) ---
 const char* ssid = WIFI_SSID;
 const char* password = WIFI_PASSWORD;
-
-// Heartbeat / notification-api configuration
-// Contract: device issues HTTP GET to the resolved endpoint; success = HTTP 200.
-// notification-api (legacy): GET /heartbeat/{device_id}  e.g. /heartbeat/poop
-// Generic health example: set heartbeatPath = "/health" (or any path your probe accepts).
-// Base URL must not include a trailing slash.
-const char* heartbeatBaseUrl = "http://notifications.archerfamily.io";
-const char* heartbeatDeviceId = "poop";
-// Leave empty to use /heartbeat/{heartbeatDeviceId}. Override for non-notification-api targets.
-const char* heartbeatPath = "";
-
-static char heartbeatEndpointBuf[256];
-static bool heartbeatEndpointReady = false;
-
-const char* getHeartbeatEndpoint() {
-  if (!heartbeatEndpointReady) {
-    if (heartbeatPath != nullptr && heartbeatPath[0] != '\0') {
-      snprintf(heartbeatEndpointBuf, sizeof(heartbeatEndpointBuf), "%s%s",
-               heartbeatBaseUrl, heartbeatPath);
-    } else {
-      snprintf(heartbeatEndpointBuf, sizeof(heartbeatEndpointBuf), "%s/heartbeat/%s",
-               heartbeatBaseUrl, heartbeatDeviceId);
-    }
-    heartbeatEndpointReady = true;
-  }
-  return heartbeatEndpointBuf;
-}
-
 const char* otaPassword = OTA_PASSWORD;
+const char* pushoverToken = PUSHOVER_TOKEN;
+const char* pushoverUser = PUSHOVER_USER;
+const char* mqttUser = MQTT_USER;
+const char* mqttPassword = MQTT_PASSWORD;
+
+// --- Non-secret device config (safe to commit; edit for your network) ---
+const char* apiEndpoint = "http://notifications.archerfamily.io/heartbeat/poop";
 const char* deviceName = "poop-monitor";
 
 // DNS Configuration
-// Use DISTINCT servers so fallback is real. Same IP for both makes failover a no-op.
-// Recommended: primary = local recursive/filter (Pi-hole, AdGuard, etc.);
-//              fallback = a second resolver (another local box or a public DNS).
-IPAddress primaryDNS(192, 168, 68, 51);  // Local DNS example (e.g. Pi-hole)
-IPAddress fallbackDNS(1, 1, 1, 1);      // Distinct fallback example (Cloudflare)
+IPAddress primaryDNS(192, 168, 68, 51);    // Your custom DNS server
+IPAddress fallbackDNS(192, 168, 68, 51);
 
-// Pushover Configuration (from credentials.h)
-const char* pushoverToken = PUSHOVER_TOKEN;
-const char* pushoverUser = PUSHOVER_USER;
+// Pushover API (public endpoint; tokens stay in credentials_private.h)
 const char* pushoverApiUrl = "https://api.pushover.net/1/messages.json";
 
-// MQTT Configuration
-const char* mqttServer = "homeassistant.local";      // Your MQTT broker IP
-const int mqttPort = 1883;                     // MQTT port (1883 or 8883 for SSL)
-const char* mqttUser = MQTT_USER;                     // MQTT username (empty if no auth)
-const char* mqttPassword = MQTT_PASSWORD;                 // MQTT password (empty if no auth)
+// MQTT broker (host/port are not secrets; auth is via MQTT_USER / MQTT_PASSWORD)
+const char* mqttServer = "homeassistant.local";  // Your MQTT broker hostname or IP
+const int mqttPort = 1883;                       // 1883 or 8883 for SSL

--- a/src/credentials.h
+++ b/src/credentials.h
@@ -1,8 +1,39 @@
 #pragma once
-extern const char* WIFI_SSID;
-extern const char* WIFI_PASSWORD;
-extern const char* OTA_PASSWORD;
-extern const char* PUSHOVER_TOKEN;
-extern const char* PUSHOVER_USER;
-extern const char* MQTT_USER;
-extern const char* MQTT_PASSWORD;
+
+// -----------------------------------------------------------------------------
+// Credentials boundary
+//
+// Secrets come from src/credentials_private.h (copy credentials.template.h).
+// Non-secret device config lives in config.cpp / config.h.
+//
+// Missing or incomplete private credentials fail at compile time with a clear
+// #error — not a cryptic linker "undefined reference".
+// -----------------------------------------------------------------------------
+
+#if defined(__has_include)
+#  if __has_include("credentials_private.h")
+#    include "credentials_private.h"
+#  endif
+#endif
+
+#ifndef WIFI_SSID
+#  error "Missing WIFI_SSID. Copy credentials.template.h to src/credentials_private.h and set your secrets."
+#endif
+#ifndef WIFI_PASSWORD
+#  error "Missing WIFI_PASSWORD. Copy credentials.template.h to src/credentials_private.h and set your secrets."
+#endif
+#ifndef OTA_PASSWORD
+#  error "Missing OTA_PASSWORD. Copy credentials.template.h to src/credentials_private.h and set your secrets."
+#endif
+#ifndef PUSHOVER_TOKEN
+#  error "Missing PUSHOVER_TOKEN. Copy credentials.template.h to src/credentials_private.h and set your secrets."
+#endif
+#ifndef PUSHOVER_USER
+#  error "Missing PUSHOVER_USER. Copy credentials.template.h to src/credentials_private.h and set your secrets."
+#endif
+#ifndef MQTT_USER
+#  error "Missing MQTT_USER. Copy credentials.template.h to src/credentials_private.h and set your secrets (use \"\" if unused)."
+#endif
+#ifndef MQTT_PASSWORD
+#  error "Missing MQTT_PASSWORD. Copy credentials.template.h to src/credentials_private.h and set your secrets (use \"\" if unused)."
+#endif

--- a/test_versioning_fix.py
+++ b/test_versioning_fix.py
@@ -67,7 +67,7 @@ def main():
             "files": [
                 ".github/copilot-instructions.md", ".github/workflows/build-and-tag.yml",
                 ".gitignore", ".vscode/arduino.json", ".vscode/extensions.json",
-                "CHANGES.md", "README.md", "credentials.template.cpp",
+                "CHANGES.md", "README.md", "credentials.template.cpp", "credentials.template.h",
                 "docs/VERSION_TAGGING.md", "features.md", "k8s/Dockerfile",
                 "k8s/deployment.yaml", "scripts/version_manager.py", "scripts/deploy_web.sh",
                 "src/config.cpp", "src/config.h", "src/main.cpp", "src/mqtt_manager.cpp",


### PR DESCRIPTION
## Summary
Makes the credentials vs non-secret config split hard to mis-flash by enforcing required secret macros at compile time and documenting the template → private file path clearly.

## Changes
- **`credentials.template.h`**: new template; copy to `src/credentials_private.h` (gitignored)
- **`src/credentials.h`**: `#error` for each missing credential macro (`WIFI_SSID`, `WIFI_PASSWORD`, `OTA_PASSWORD`, `PUSHOVER_*`, `MQTT_*`)
- **`src/config.cpp`**: secrets wired from macros; non-secrets (MQTT host, DNS, device name) stay committed
- **CI**: copies `credentials.template.h` → `src/credentials_private.h` instead of inline stubs
- **README**: setup docs for template → real credentials

## Acceptance criteria
- [x] Compile-time checks for missing credential macros
- [x] Clear build docs for template → real credentials
- [x] CI builds with dummy credentials template

## Validation
- `pio run -e esp32-c3-devkitm-1` succeeds with template credentials
- Build without `credentials_private.h` fails with clear `#error` messages

Closes #33